### PR TITLE
元々半分幅な文字は縮めると細すぎるので縮めずそのまま半分領域を使う

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://github.com/uwabami/locale-eaw-emoji/blob/master/EastAsianAmbiguous.txt
 ![udeawn](https://user-images.githubusercontent.com/761487/220837764-7cb16f09-4249-4f91-b6d6-e9edaa5db21c.png)
 
 ## UDEAWH font
-BIZ UDゴシック内のEast Asian Ambiguous文字をFontForgeで半分の幅に縮めためもの。
+BIZ UDゴシック内のEast Asian Ambiguous文字をFontForgeで半分の幅に縮めたもの。
 
 単に縮めているので、縦線が細めです。丸数字等が縦長です。
 

--- a/copyright-h.sh
+++ b/copyright-h.sh
@@ -10,9 +10,6 @@ FONT_PATTERN=${PREFIX}${FAMILYNAME}'*.ttf'
 COPYRIGHT='[BIZ UDGothic]
 Copyright 2022 The BIZ UDGothic Project Authors (https://github.com/googlefonts/morisawa-biz-ud-gothic)
 
-[UDEV Gothic]
-Copyright (c) 2022, Yuko Otawara
-
 [UDEAWN]
 Copyright (c) 2023 KIHARA, Hideto'
 

--- a/generator-h.sh
+++ b/generator-h.sh
@@ -66,6 +66,40 @@ while (i < SizeOf(input_list))
   UnlinkReference()
 
   # East Asian Ambiguousなグリフの幅を半分にする
+  # ただし、元々半分幅な文字は縮めると細すぎるので縮めずそのまま使う
+  eaw_useright = [0x2018, 0x201C]
+  eaw_useleft = [0x00B0, 0x2019, 0x201D, 0x2032, 0x2033]
+  # 右半分だけにする
+  array_end = SizeOf(eaw_useright)
+  j = 0
+  while (j < array_end)
+    ucode = eaw_useright[j]
+    if (WorthOutputting(ucode))
+      Select(ucode)
+      w = GlyphInfo("Width")
+      if (w > 0 && w > ${HALF_WIDTH})
+        Move(-${HALF_WIDTH}, 0)
+        SetWidth(${HALF_WIDTH}, 0)
+      endif
+    endif
+    j++
+  endloop
+
+  # 左半分だけにする
+  array_end = SizeOf(eaw_useleft)
+  j = 0
+  while (j < array_end)
+    ucode = eaw_useleft[j]
+    if (WorthOutputting(ucode))
+      Select(ucode)
+      w = GlyphInfo("Width")
+      if (w > 0 && w > ${HALF_WIDTH})
+        SetWidth(${HALF_WIDTH}, 0)
+      endif
+    endif
+    j++
+  endloop
+
   # https://github.com/uwabami/locale-eaw-emoji/blob/master/EastAsianAmbiguous.txt
   eaw_array = [ \\
     0x00A1, 0x00A4, 0x00A7, 0x00A8, 0x00AA, 0x00AD, 0x00AE, 0x00B0, 0x00B1, \\
@@ -188,7 +222,7 @@ while (i < SizeOf(input_list))
       if (w > 0 && w > ${HALF_WIDTH})
         # 幅を半分にする
         Scale(${SHRINK_X}, ${SHRINK_Y}, 0, 0)
-        SetWidth(${ORIG_HALF_WIDTH}, 0)
+        SetWidth(${HALF_WIDTH}, 0)
       endif
     endif
     j++

--- a/generator.sh
+++ b/generator.sh
@@ -324,7 +324,8 @@ while (i < SizeOf(input_list))
   SelectWorthOutputting()
   UnlinkReference()
 
-  # East Asian AmbiguousなグリフをBIZ UDゴシックから削除
+  # East Asian Ambiguousなグリフのうち、Illusion-Nにあるものは
+  # BIZ UDゴシックから削除。Illusion-Nにないものは半分幅にする。
   j = 0
   while (j < array_end)
     ucode = eaw_array[j]
@@ -332,6 +333,13 @@ while (i < SizeOf(input_list))
       Select(ucode)
       if (exist_glyph_array[j] == 1)
         Clear()
+      else
+        w = GlyphInfo("Width")
+        if (w > 0 && w > ${HALF_WIDTH})
+          # 幅を半分にする
+          Scale(50, 100, 0, 0)
+          SetWidth(${HALF_WIDTH}, 0)
+        endif
       endif
     endif
     j++

--- a/make-h.sh
+++ b/make-h.sh
@@ -4,7 +4,7 @@ BASE_DIR=$(cd $(dirname $0); pwd)
 WORK_DIR="$BASE_DIR/build_tmp"
 BUILD_DIR="$BASE_DIR/build"
 
-VERSION='0.0.4'
+VERSION='0.0.5'
 
 FAMILYNAME="UDEAWH"
 DISP_FAMILYNAME="UDEAWH"

--- a/make.sh
+++ b/make.sh
@@ -4,7 +4,7 @@ BASE_DIR=$(cd $(dirname $0); pwd)
 WORK_DIR="$BASE_DIR/build_tmp"
 BUILD_DIR="$BASE_DIR/build"
 
-VERSION='0.0.3'
+VERSION='0.0.5'
 
 FAMILYNAME="UDEAWN"
 DISP_FAMILYNAME="UDEAWN"


### PR DESCRIPTION
* UDEAWH: 元々半分幅な文字は縮めると細すぎるので縮めずそのまま半分領域を使う。
`°‘’“”′″`
![udeawh-wsltty](https://user-images.githubusercontent.com/761487/221339824-8806426a-9a24-4615-bd61-1dbdbdfecc9e.png)

* UDEAWN: Illusion-Nに無いambiguousな文字は、元を半分幅に縮めたものにする
![udeawn-wsltty](https://user-images.githubusercontent.com/761487/221339817-37f4fedb-dd5b-411d-b764-b9a2ff2d9d74.png)

(wslttyで表示した場合、UDEAWN/UDEAWHに含まれていない文字も表示されている)